### PR TITLE
Pass strings to defined, not variables of strings

### DIFF
--- a/docassemble/AKA2JBranding/data/questions/feedback.yml
+++ b/docassemble/AKA2JBranding/data/questions/feedback.yml
@@ -178,11 +178,11 @@ subject: |
 content: | 
   ## How helpful was this form?
   Choices are "very helpful", "somewhat helpful", "not helpful at all".
-  % if defined(how_helpful):
+  % if defined("how_helpful"):
   ${ how_helpful }
   % endif
   ## What best describes you?
-   % if defined(user_type):
+   % if defined("user_type"):
   ${ user_type }
   % endif
   


### PR DESCRIPTION
I was trying to recreate the issues that you were running into when trying to make issues on private repos, but wasn't able. I did run into this error though, that I figured I should help you fix.

`defined` expects to get some python code. However, if you pass it a string, it will try to evaluate the contents of the strings as python code. It would give me an error saying "A little helpful" had a syntax error. Passing in the string of the name of the variable fixed the issue for me.