### PR TITLE
Import guards on weaver advertisement

### DIFF
--- a/docassemble/AKA2JBranding/advertise_weaver.py
+++ b/docassemble/AKA2JBranding/advertise_weaver.py
@@ -1,7 +1,11 @@
 # pre-load
 import os
-from docassemble.ALWeaver.custom_values import advertise_capabilities
+from docassemble.base.util import log
 
-if not os.environ.get('ISUNITTEST'):
-    advertise_capabilities(__name__, minimum_version="1.5")
+try:
+    from docassemble.ALWeaver.custom_values import advertise_capabilities
+    if not os.environ.get('ISUNITTEST'):
+        advertise_capabilities(__name__, minimum_version="1.5")
 
+except ImportError:
+    log("Not advertising capabilities because ALWeaver is not installed.")

--- a/docassemble/AKA2JBranding/advertise_weaver.py
+++ b/docassemble/AKA2JBranding/advertise_weaver.py
@@ -1,11 +1,10 @@
 # pre-load
 import os
-from docassemble.base.util import log
-
 try:
     from docassemble.ALWeaver.custom_values import advertise_capabilities
     if not os.environ.get('ISUNITTEST'):
         advertise_capabilities(__name__, minimum_version="1.5")
 
 except ImportError:
+    from docassemble.base.util import log
     log("Not advertising capabilities because ALWeaver is not installed.")


### PR DESCRIPTION
When the Weaver isn't installed on a given server, currently this file adds an annoying log message that clutters up Docassemble.log.

This PR adds try/except logic so it doesn't attempt to advertise when it can't and it isn't needed to do so